### PR TITLE
fix(angular): skeleton image should not add style width and height

### DIFF
--- a/src/angular/lib/skeleton-image.ts
+++ b/src/angular/lib/skeleton-image.ts
@@ -8,8 +8,6 @@ import { multiplySvgPointsService } from './multiply-svg-points';
     '[class.skeleton-effect-fade]': 'effect === "fade"',
     '[class.skeleton-effect-pulse]': 'effect === "pulse"',
     '[class.skeleton-effect-wave]': 'effect === "blink" || effect === "wave"',
-    '[style.width.px]': 'width',
-    '[style.height.px]': 'height',
   },
   template: `<svg
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
By mistake, I was adding `width` and `height` to `skeleton-image`
As a result this css was not applying:
```scss
.skeleton-image svg {
    width: 100%;
    height: auto;
  }
```

you can see this comparing examples in react and angular:
Angular: https://stackblitz.com/edit/skeletonelements-image-angular?file=src/app/app.component.html
React: https://codesandbox.io/s/skeletonimage-react-8q1os?from-embed