### PR TITLE
fix(styles): make width -> max-width

### DIFF
--- a/src/scss/avatar.scss
+++ b/src/scss/avatar.scss
@@ -1,7 +1,7 @@
 .skeleton-avatar {
   display: inline-block;
   svg {
-    width: 100%;
+    max-width: 100%;
     height: auto;
   }
   rect {

--- a/src/scss/image.scss
+++ b/src/scss/image.scss
@@ -1,7 +1,7 @@
 .skeleton-image {
   display: inline-block;
   svg {
-    width: 100%;
+    max-width: 100%;
     height: auto;
   }
   polygon {


### PR DESCRIPTION
`width: 100%` is forcing the svg to take all the width, instead of using parameter (width & height).
Using `max-width` seems more appropriate.
see examples:

**with `width: 100%`:**
![image](https://user-images.githubusercontent.com/5851280/100714318-46d37c80-33be-11eb-9518-2391b7073691.png)

**with `max-width: 100%`:**
![image](https://user-images.githubusercontent.com/5851280/100714352-50f57b00-33be-11eb-849a-831bcc2a66ba.png)
